### PR TITLE
Update end-of-life runtime to 22.08

### DIFF
--- a/gg.guilded.Guilded.yml
+++ b/gg.guilded.Guilded.yml
@@ -1,8 +1,8 @@
 app-id: gg.guilded.Guilded
 base: org.electronjs.Electron2.BaseApp
-base-version: '20.08'
+base-version: '22.08'
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: guilded
 tags:


### PR DESCRIPTION
Resolves freedesktop runtime end-of-life, thanks @Tealk https://github.com/flathub/gg.guilded.Guilded/issues/18.